### PR TITLE
stringToChars and charsToString

### DIFF
--- a/src/canary/metta_eval.pl
+++ b/src/canary/metta_eval.pl
@@ -1176,7 +1176,10 @@ get_symbol_metatype(Val,_Want,Type):- nb_current(Val,NewVal),'get-metatype'(NewV
 get_symbol_metatype(_Vl,'%Undefined%','Symbol').
 get_symbol_metatype(_Vl,_Want,'Grounded').
 
+as_metta_char(X,'#\\'(X)).
 
+eval_20(Eq,RetType,Depth,Self,['stringToChars',String],Chars):- !, eval_args(Eq,RetType,Depth,Self,String,SS), !, string_chars(SS,Chars0),maplist(as_metta_char,Chars0,Chars).
+eval_20(Eq,RetType,Depth,Self,['charsToString',Chars],String):- !, eval_args(Eq,RetType,Depth,Self,Chars,CC), !, maplist(as_metta_char,CC0,CC),string_chars(String,CC0).
 
 
 % =================================================================

--- a/src/canary/metta_interp.pl
+++ b/src/canary/metta_interp.pl
@@ -605,6 +605,12 @@ show_options_values:-
 % Get Type of Value
 'get-type'(Value, Type):- eval_H(['get-type', Value], Type).
 
+% ============================
+% %%%% String Utilities
+% ============================
+% conversion between String and List of Chars
+'stringToChars'(String, Chars) :- eval_H(['stringToChars', String], Chars).
+'charsToString'(Chars, String) :- eval_H(['charsToString', Chars], String).
 
 metta_argv(Args):- current_prolog_flag(metta_argv, Args),!.
 metta_argv(Before):- current_prolog_flag(os_argv,OSArgv), append(_,['--args'|AArgs],OSArgv),

--- a/src/canary/metta_ontology.pfc.pl
+++ b/src/canary/metta_ontology.pfc.pl
@@ -458,4 +458,7 @@ properties('&corelib','tuple-count', [data_structures, qhelp("Counts tuples with
 %properties('&corelib','TupleConcat', [data_structures, qhelp("Concatenates tuples."), concatenation]).
 %properties('&corelib','collapseCardinality', [data_structures, qhelp("Collapses structures with cardinality consideration."), manipulation, cardinality]).
 
+% --- String and Character manipulation ---
+properties('&corelib','stringToChars', [string_operations, qhelp("Convert a string to a list of chars."), string_to_chars]).
+properties('&corelib','charsToString', [string_operations, qhelp("Convert a list of chars to a string."), chars_to_string]).
 

--- a/src/canary/metta_printer.pl
+++ b/src/canary/metta_printer.pl
@@ -106,6 +106,7 @@ write_val(V):- write('"'),write(V),write('"').
 % Handling the final write when the value is a variable or a '$VAR' structure.
 is_final_write(V):- var(V), !, write_dvar(V),!.
 is_final_write('$VAR'(S)):-  !, write_dvar(S),!.
+is_final_write('#\\'(S)):-  !, format("'~w'",[S]).
 is_final_write([VAR,V|T]):- '$VAR'==VAR, T==[], !, write_dvar(V).
 is_final_write('[|]'):- write('Cons'),!.
 is_final_write([]):- !, write('()').

--- a/tests/baseline_compat/hyperon-mettalog_sanity/string-tests.metta
+++ b/tests/baseline_compat/hyperon-mettalog_sanity/string-tests.metta
@@ -6,7 +6,7 @@
 
 !(charsToString ())
 
-; this one works differently in metta and mettalog
+;; this one works differently in metta and mettalog
 !(charsToString (stringToChars "xyzzy"))
 
 !(stringToChars (charsToString ('x' 'y' 'z' 'z' 'y')))

--- a/tests/baseline_compat/hyperon-mettalog_sanity/string-tests.metta
+++ b/tests/baseline_compat/hyperon-mettalog_sanity/string-tests.metta
@@ -6,6 +6,7 @@
 
 !(charsToString ())
 
+; this one works differently in metta and mettalog
 !(charsToString (stringToChars "xyzzy"))
 
 !(stringToChars (charsToString ('x' 'y' 'z' 'z' 'y')))

--- a/tests/baseline_compat/hyperon-mettalog_sanity/string-tests.metta
+++ b/tests/baseline_compat/hyperon-mettalog_sanity/string-tests.metta
@@ -1,0 +1,11 @@
+!(stringToChars "xyzzy")
+
+!(charsToString ('x' 'y' 'z' 'z' 'y'))
+
+!(stringToChars "")
+
+!(charsToString ())
+
+!(charsToString (stringToChars "xyzzy"))
+
+!(stringToChars (charsToString ('x' 'y' 'z' 'z' 'y')))

--- a/tests/baseline_compat/hyperon-mettalog_sanity/string-tests.metta.answers
+++ b/tests/baseline_compat/hyperon-mettalog_sanity/string-tests.metta.answers
@@ -1,0 +1,6 @@
+[('x' 'y' 'z' 'z' 'y')]
+["xyzzy"]
+[()]
+[""]
+["tringToCharxyzzy"]
+[('x' 'y' 'z' 'z' 'y')]


### PR DESCRIPTION
added stringToChars and charsToString to the mettalog interpreter.

One test fails - I think there is some difference in evaluation handling:

!(charsToString (stringToChars "xyzzy"))

rust metta: ["tringToCharxyzzy"]

mettalog: ["xyzzy"]

