### PR TITLE
Allow for late definition to be evaluated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY ./ ./
 # get rid of copied venv that is probably using a whole different python anyways
 RUN rm -rf ./venv/  
 COPY ./INSTALL.sh ./INSTALL.sh
+RUN apt install dos2unix
 SHELL ["/bin/bash", "-c"]
 RUN source ./INSTALL.sh --easy
 

--- a/src/canary/metta_eval.pl
+++ b/src/canary/metta_eval.pl
@@ -2498,12 +2498,12 @@ len_or_unbound(_,_).
 :- nodebug(metta('defn')).
 
 eval_maybe_defn(Eq,RetType,Depth,Self,X,Res):-
+    \+ fail_on_constructor,
    \+  \+ (curried_arity(X,F,A),
            is_metta_type_constructor(Self,F,AA),
            ( \+ AA\=A ),!,
            if_trace(e,color_g_mesg('#772000',
                  indentq2(Depth,defs_none_cached((F/A/AA)=X))))),!,
-   \+ fail_on_constructor,
    eval_constructor(Eq,RetType,Depth,Self,X,Res).
 eval_maybe_defn(Eq,RetType,Depth,Self,X,Y):- can_be_ok(eval_maybe_defn,X),!,
       trace_eval(eval_defn_choose_candidates(Eq,RetType),'defn',Depth,Self,X,Y).

--- a/src/canary/metta_interp.pl
+++ b/src/canary/metta_interp.pl
@@ -2013,7 +2013,7 @@ fix_message_hook:-
 
 :- ensure_loaded(metta_python).
 :- ensure_loaded(metta_corelib).
-:- ensure_loaded(metta_help).
+% :- ensure_loaded(metta_help).
 :- initialization(use_corelib_file).
 
 :- ignore(((


### PR DESCRIPTION
Fixes to allow for late function definition to be correctly evaluated. This is likely related to issue #127 