### PR TITLE
[lsp] Handle unnecessary codeAction/resolve requests

### DIFF
--- a/libraries/lsp_server_metta/prolog/lsp_metta_code_actions.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_code_actions.pl
@@ -272,7 +272,7 @@ lsp_hooks:handle_msg_hook("codeAction/resolve", Msg,
                                       kind: "refactor.comment",
                                       edit: _{changes: Changes}}}) :-
     _{id: Id, params: Params} :< Msg,
-    _{data: Data, kind: "refactor.comment"} :< Params,
+    _{data: Data, kind: "refactor.comment"} :< Params, !,
     _{uri: Uri, range: Range} :< Data,
     get_code_at_range(exact, Uri, Range, Code),
     request_code_comment(Code, Commented),
@@ -283,6 +283,11 @@ lsp_hooks:handle_msg_hook("codeAction/resolve", Msg,
     % using dict_create/3 instead of a literal because that doesn't
     % seem to work with a variable key
     dict_create(Changes, _, [AUri=[_{range: Range, newText: Commented}]]).
+% VSCode still sends a resolve request, even when the message has what it needs?
+lsp_hooks:handle_msg_hook("codeAction/resolve", Msg, Result) :-
+    _{id: Id, params: Params} :< Msg,
+    Result = _{id: Id, result: Params}.
+
 
 % The call_openai_for_gpt_task/3 predicate is defined earlier.
 

--- a/libraries/lsp_server_metta/prolog/lsp_server_metta.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_server_metta.pl
@@ -666,7 +666,10 @@ server_capabilities(
         % Popups
         hoverProvider: true,
         codeLensProvider: _{resolveProvider: true},  % Code lens resolve provider enabled to support resolving additional data on code lenses
-        codeActionProvider: _{resolveProvider: true},  % Enabled to support code actions
+        % Enabled to support code actions
+        codeActionProvider: _{resolveProvider: true,
+                              dataSupport: true,
+                              resolveSupport: ["edit"]},
         % Dynamically enumerate commands for Popups
         executeCommandProvider: _{
             commands: CommandsList  % List available Code Lens commands


### PR DESCRIPTION
The client should only send this request if the action is missing edit or command, but VSCode sends this anyway, so just respond back with what it already has.