### PR TITLE
LLM completion interaction changes

### DIFF
--- a/libraries/lsp_server_metta/README.md
+++ b/libraries/lsp_server_metta/README.md
@@ -370,6 +370,8 @@ ollama create llama3-metta -f libraries/lsp_server_metta/Modelfile
 
 Then configure start your server or configure your editor as indicated under [Configuring Your Editor For LLM Usage](#configuring-your-editor-for-llm-usage), except instead of setting `OPENAI_API_KEY` to whatever value, set `METTA_LLM_URL` to `http://localhost:11434/api/generate` and set `METTA_LLM_MODEL` to `llama3-metta`.
 
+The LSP server can also use LLMs for code completion, however it is disabled by default, is it is currently fairly slow (compared to normal completion). If you're okay with this or have a fast-enough LLM, you can enable it by setting the environment variable `LSP_LLM_COMPLETE_INLINE` to `true` when starting the server, in a similar manner as the other variables for your respective editor below.
+
 ### Configuring Your Editor For LLM Usage
 
 #### VSCode

--- a/libraries/lsp_server_metta/prolog/lsp_metta_completion.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_completion.pl
@@ -1,36 +1,39 @@
-% :- module(lsp_metta_completion, [completions_at/3]).
-% /** <module> LSP Completion
-%
-% This module implements code completion, based on defined predicates in
-% the file & imports.
-%
-% Uses =lsp_metta_changes= in order to see the state of the buffer being edited.
-%
-% @see lsp_metta_changes:doc_text_fallback/2
-%
-% @author James Cash
-% */
-%
+:- module(lsp_metta_completion, [completions_at/3]).
+/** <module> LSP Completion
+
+This module implements code completion, based on defined predicates in
+the file & imports.
+
+Uses =lsp_metta_changes= in order to see the state of the buffer being edited.
+
+@see lsp_metta_changes:doc_text_fallback/2
+
+@author James Cash
+*/
+
 
 % Douglas added
-:- use_module(library(http/http_open)).  % For making HTTP requests
-:- use_module(library(http/json)).       % For handling JSON
+:- use_module(library(http/http_open)).   % For making HTTP requests
+:- use_module(library(http/json)).        % For handling JSON
 :- use_module(library(http/http_header)).
 
 :- use_module(library(apply), [maplist/3]).
 :- use_module(library(lists), [numlist/3]).
 :- use_module(library(yall)).
 :- use_module(library(filesex)).
-%:- use_module(lsp_metta_utils, [linechar_offset/3]).
+
+:- include(lsp_metta_include).
+
+:- use_module(lsp_prolog_utils, [linechar_offset/3]).
 :- use_module(lsp_metta_changes, [doc_text_fallback_d4/2]).
+
 
 :- use_module(lsp_metta_llm, [is_llm_enabled/0,
                               request_code_completion/2]).
 
 
-:- include(lsp_metta_include).
 
-:- use_module(lsp_metta_workspace, [source_file_text/2, xref_metta_source/1]).
+:- use_module(lsp_metta_workspace).
 
 :- discontiguous(handle_completions/3).
 

--- a/libraries/lsp_server_metta/vscode/extension.js
+++ b/libraries/lsp_server_metta/vscode/extension.js
@@ -38,6 +38,7 @@ function activate(context) {
   const chatgptApiKey = config.get("xtras.chatgpt.apiKey", "");
   const chatgptAltUrl = config.get("xtras.chatgpt.alternateUrl", "");
   const chatgptModel = config.get("xtras.chatgpt.model", "gpt-3.5-turbo");
+  const useChatgptCompletion = config.get("xtras.chatgpt.inlineCompletion", false);
 
   const loadLspSrc = debugLsp && mettalogPath !== '';
   const lspSrcPath = mettalogPath + "/libraries/lsp_server_metta/prolog/lsp_server_metta.pl";
@@ -50,7 +51,8 @@ function activate(context) {
   if (chatgptEnabled) {
     const envAdditions = {"OPENAI_API_KEY": chatgptApiKey,
                           "METTA_LLM_URL": chatgptAltUrl,
-                          "METTA_LLM_MODEL": chatgptModel}
+                          "METTA_LLM_MODEL": chatgptModel,
+                          "LSP_LLM_COMPLETE_INLINE": useChatgptCompletion};
     Object.keys(envAdditions).forEach(key => {
       if (envAdditions[key] !== '') {
         env[key] = envAdditions[key];
@@ -315,6 +317,7 @@ function showMettaLSPSettings(outputChannel) {
     "xtras.chatgpt.model",
     "xtras.chatgpt.maxTokens",
     "xtras.chatgpt.temperature",
+    "xtras.chatgpt.inlineCompletion",
     "server.mode",
     "server.spawnProcess",
     "server.port",

--- a/libraries/lsp_server_metta/vscode/package.json
+++ b/libraries/lsp_server_metta/vscode/package.json
@@ -135,6 +135,12 @@
           "default": "",
           "description": "Specifies the URL used for sending requests to a non-OpenAI (presumably local) LLM model."
         },
+        "metta-lsp.xtras.chatgpt.inlineCompletion": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the configured LLM as a source for completions. Note this may slow down completion options being disabled significantly."
+        },
         "metta-lsp.xtras.chatgpt.apiKey": {
           "scope": "window",
           "type": "string",


### PR DESCRIPTION
This PR makes it possible to disable including LLM results in the normal completion (since it makes it much slower), without fully disabling LLM integration. It also adds a code action complete with an LLM, so it's still available for manual use.

Ideally, there would be a way to asynchronously add results to the completion list or have the code action provide a list of completions to choose from (currently it just applies the first completion), but neither seem possible with the current state of the LSP specification.