### PR TITLE
Fix/math operations random generators

### DIFF
--- a/prolog/metta_lang/metta_eval.pl
+++ b/prolog/metta_lang/metta_eval.pl
@@ -4288,7 +4288,7 @@ allow_clp:- false_flag.
 eval_selfless_1([F|XY],TF):- allow_clp, \+ ground(XY),!,fake_notrace(args_to_mathlib(XY,Lib)),!,eval_selfless3(Lib,[F|XY],TF).
 eval_selfless_1(['>',X,Y],TF):-!,as_tf_nowarn(X>Y,TF).
 eval_selfless_1(['<',X,Y],TF):-!,as_tf_nowarn(X<Y,TF).
-eval_selfless_1(['=>',X,Y],TF):-!,as_tf_nowarn(X>=Y,TF).
+eval_selfless_1(['>=',X,Y],TF):-!,as_tf_nowarn(X>=Y,TF).
 eval_selfless_1(['<=',X,Y],TF):-!,as_tf_nowarn(X=<Y,TF).
 eval_selfless_1(['\\=',X,Y],TF):-!,as_tf(dif(X,Y),TF).
 
@@ -4316,7 +4316,7 @@ compare_selfless0(_,[F|_],_TF):- \+ atom(F),!,fail.
 compare_selfless0(clpfd,['\\=',X,Y],TF):-!,as_tf(X #\=Y,TF).
 %compare_selfless0(clpfd,['>',X,Y],TF):-!,as_tf(X#>Y,TF).
 %compare_selfless0(clpfd,['<',X,Y],TF):-!,as_tf(X#<Y,TF).
-compare_selfless0(clpfd,['=>',X,Y],TF):-!,as_tf(X#>=Y,TF).
+compare_selfless0(clpfd,['>=',X,Y],TF):-!,as_tf(X#>=Y,TF).
 compare_selfless0(clpfd,['<=',X,Y],TF):-!,as_tf(X#=<Y,TF).
 %compare_selfless0(clpfd,[F|Stuff],TF):- atom_concat('#',F,SharpF),P=..[SharpF|Stuff],!,as_tf(P,TF).
 compare_selfless0(Lib,_,_):- Lib == clpfd,!,fail.
@@ -4324,7 +4324,7 @@ compare_selfless0(Lib,['\\=',X,Y],TF):-!,as_tf(Lib:{X \=Y}, TF).
 compare_selfless0(Lib,['=',X,Y],TF):-!,as_tf(Lib:{X =Y}, TF).
 compare_selfless0(Lib,['>',X,Y],TF):-!,as_tf(Lib:{X>Y},TF).
 compare_selfless0(Lib,['<',X,Y],TF):-!,as_tf(Lib:{X<Y},TF).
-compare_selfless0(Lib,['=>',X,Y],TF):-!,as_tf(Lib:{X>=Y},TF).
+compare_selfless0(Lib,['>=',X,Y],TF):-!,as_tf(Lib:{X>=Y},TF).
 compare_selfless0(Lib,['<=',X,Y],TF):-!,as_tf(Lib:{X=<Y},TF).
 compare_selfless0(Lib,[F|Stuff],TF):- P=..[F|Stuff],!,as_tf(Lib:{P},TF).
 

--- a/prolog/metta_lang/metta_eval.pl
+++ b/prolog/metta_lang/metta_eval.pl
@@ -3813,6 +3813,10 @@ pre_post_functor_va(post,mx_n).
 
 :- dynamic(m_head_impl/4).
 m_head_impl('random-int',3,post,mx).
+m_head_impl('random-float',3,post,mx).  
+m_head_impl('new-random-generator',1,post,mx). 
+m_head_impl('set-random-seed',2,post,mx). 
+m_head_impl('reset-random-generator',1,post,mx).
 
 :- dynamic(m_head_impl_va/4).
 m_head_impl_va('py-dot!',2,post,mc_n).
@@ -3828,9 +3832,8 @@ m_head_impl(Pre,Sym,Len, Type,Fn, Min, restAsList):-
    m_head_impl_va(Sym,Min,Pre,IsType), Min =< Len, !, Fn =.. [IsType,Min,Sym].
 
 
-transpiler_peek(Pre,Sym,Len,TypeL,Fn, Min, SpreadArgs):- nonvar(Sym),
-  member(Sym,['random-int','random-seed']),
-  transpiler_peek_impl(Pre,Sym,Len,TypeL,Fn, Min, SpreadArgs),
+transpiler_peek(Pre,Sym,Len,TypeL,Fn, Min, SpreadArgs):-  
+  transpiler_peek_impl(Pre,Sym,Len,TypeL,Fn, Min, SpreadArgs),  
   debug_info(always(compiler),transpiler_peek(Pre,Sym,Len,TypeL,Fn, Min, SpreadArgs)).
 
 transpiler_peek_impl(Pre,Sym,Len,TypeL,Fn, Min, SpreadArgs):-

--- a/prolog/metta_lang/metta_types.pl
+++ b/prolog/metta_lang/metta_types.pl
@@ -2387,6 +2387,18 @@ is_comp_op('=\\=', 2).       % Arithmetic inequality
 %     ?- is_math_op('sqrt', 1, Status).
 %     Status = exists.
 %
+% Define a 2-argument version of truncate, compatible with call-fn!
+truncate(X, R) :- R is truncate(X).
+
+% Check for NaN (Not a Number)
+isnan(X, true) :- float(X), \+ X =:= X, !.
+isnan(_, false).
+
+% Check for Infinity
+isinf(X, true) :- float(X), (X =:= 1.0Inf ; X =:= -1.0Inf), !.
+isinf(_, false).
+
+is_math_op('truncate', 2, exists).  % Truncate to integer
 is_math_op('*', 2, exists).         % Multiplication
 is_math_op('**', 2, exists).        % Exponentiation
 is_math_op('+', 1, exists).         % Unary Plus

--- a/prolog/metta_lang/stdlib_mettalog.metta
+++ b/prolog/metta_lang/stdlib_mettalog.metta
@@ -970,7 +970,7 @@ For example:
   (@params (
     (@param "Float value")))
   (@return "Integer part of float"))
-(is-op-1 trunc-math trunc)
+(= (trunc-math $x) (call-fn! truncate $x))
 
 (iz ceil-math MeTTa)
 (@doc ceil-math
@@ -1050,7 +1050,8 @@ For example:
   (@params (
     (@param "Number")))
   (@return "True/False"))
-(is-pred isnan-math is_NaN)
+; (is-pred isnan-math is_NaN) 
+(= (isnan-math $x) (call-fn! isnan $x))
 
 (iz isinf-math MeTTa)
 (@doc isinf-math
@@ -1059,8 +1060,8 @@ For example:
     (@param "Number")))
   (@return "True/False"))
 ; this is deduced: (: isinf (-> Number Bool))
-(is-pred isinf-math is_Inf)
-
+; (is-pred isinf-math is_Inf)  
+(= (isinf-math $x) (call-fn! isinf $x))
 
 
 

--- a/prolog/metta_lang/stdlib_mettalog.metta
+++ b/prolog/metta_lang/stdlib_mettalog.metta
@@ -957,7 +957,12 @@ For example:
     (@param "Base")
     (@param "Input number")))
   (@return "Result of log function"))
-(is-op-2 log-math log2)
+; (is-op-2 log-math log2) corrected this implementation
+(= (log-math $base $x)  
+  (function   
+    (eval (if (or (<= $base 0)  (or (== $base 1) (<= $x 0)))  
+      (return (Error log-math "Invalid logarithm arguments"))  
+      (return (/ (call-fn! log $x) (call-fn! log $base)))))))
 
 (iz trunc-math MeTTa)
 (@doc trunc-math

--- a/prolog/metta_lang/stdlib_mettalog.metta
+++ b/prolog/metta_lang/stdlib_mettalog.metta
@@ -1064,26 +1064,71 @@ For example:
 (= (isinf-math $x) (call-fn! isinf $x))
 
 
+(: random-int (-> RandomGenerator Number Number Number))
+(iz random-int UseRust)
+(@doc random-int
+  (@desc "Returns random int number from range defined by two numbers (second and third argument)")
+  (@params (
+    (@param "Random number generator instance")
+    (@param "Range start")
+    (@param "Range end")))
+  (@return "Random int number from defined range"))
+
+(iz random-float UseRust)
+(: random-float (-> RandomGenerator Number Number Number))
+(@doc random-float
+  (@desc "Returns random float number from range defined by two numbers (second and third argument)")
+  (@params (
+    (@param "Random number generator instance")
+    (@param "Range start")
+    (@param "Range end")))
+  (@return "Random float number from defined range"))
+
+(iz set-random-seed MeTTa)
+(iz set-random-seed UseRust)
+(: set-random-seed (-> RandomGenerator Number (->)))
+(@doc set-random-seed
+  (@desc "Sets a new seed (second argument) for random number generator (first argument)")
+  (@params (
+    (@param "Random number generator instance")
+    (@param "Seed")))
+  (@return "Unit atom"))
+
+(iz new-random-generator MeTTa)
+(iz new-random-generator UseRust)
+(: new-random-generator (-> Number RandomGenerator))
+(@doc new-random-generator
+  (@desc "Creates new random number generator instance using seed as input (first argument)")
+  (@params (
+    (@param "Seed")))
+  (@return "Instance of random number generator"))
+
+(iz reset-random-generator MeTTa)
+(: reset-random-generator (-> RandomGenerator RandomGenerator))
+(@doc reset-random-generator
+  (@desc "Resets instance of random number generator (first argument) to its default behavior (StdRng::from_os_rng())")
+  (@params (
+    (@param "Random number generator instance")))
+  (@return "Random number generator instance with default behavior"))
 
 ;; Some code still uses the old syntax
-(iz random-int-2 MeTTa)
-(@doc random-int-2
+(iz random-int MeTTa)
+(@doc random-int
   (@desc "Returns random int number from range defined by two numbers (first and second argument)")
   (@params (
 	(@param "Range start")
 	(@param "Range end")))
   (@return "Random int number from defined range"))
-(is-op-2 random-int-2 random)
+(is-op-2 random-int random)
 
-(iz random-float-2 MeTTa)
-(@doc random-float-2
+(iz random-float MeTTa)
+(@doc random-float
   (@desc "Returns random float number from range defined by two numbers (first and second argument)")
   (@params (
 	(@param "Range start")
 	(@param "Range end")))
   (@return "Random float number from defined range"))
-(is-op-2 random-int-2 random)
-
+(is-op-2 random-float random_float_between)
 
 
 


### PR DESCRIPTION
## Fix non-functional math and random operators in MeTTaLog

Some mathematical, comparison, and random operators that evaluate correctly in standard MeTTa were not working in MeTTaLog. Instead of returning results, expressions were left unevaluated or resulted in errors.

### Affected operators

- Math: `log-math`, `trunc-math`, 
- Float checks: `isinf-math`, `isnan-math`
- Random: `new-random-generator`, `set-random-seed`, `reset-random-generator`, `random-float`
- Comparison: `>=` (previously was treated as `=>`)

### Resolution

This PR adds missing backend registrations and helper predicates (e.g., `truncate/2`, `isinf/2`, `isnan/2`), registers the random family of operators with the `mx/5` handler, and corrects the interpretation of `>=`.

Additionally, significant time was spent identifying a change in `python/helpers` where the following code prevented random operators from compiling:

```prolog
transpiler_peek(Pre,Sym,Len,TypeL,Fn, Min, SpreadArgs) :- nonvar(Sym),
  member(Sym,['random-int','random-seed']),
  transpiler_peek_impl(Pre,Sym,Len,TypeL,Fn, Min, SpreadArgs),
````

By comparing commits:

```
git diff a51ad2787c8706155cb9f60133a71120cb3963e2  f46990de2392d5dd74ae0d7f0a61fe80caa55d6c -- prolog/metta_lang/metta_eval.pl
```

the source of the discrepancy was located and resolved. All listed operators now execute correctly in MeTTaLog.

