### PR TITLE
Refactor/superpose trait-based generalization

### DIFF
--- a/prolog/metta_lang/metta_compiler.pl
+++ b/prolog/metta_lang/metta_compiler.pl
@@ -2161,7 +2161,10 @@ compile_this_f(F):- buffer_src_isa(F, 'Compiled').
 compile_this_f(F):- interpet_this_f(F), !, fail.
 compile_this_f(F):- compile_this_s(F), !.
 compile_this_f(F):- buffer_src([':', F, [Ar|_]]), Ar=='->', !.
-compile_this_s('superpose').
+% OLD: compile_this_s('superpose').
+% NEW: Use trait-based checking
+compile_this_s(F) :- 
+    is_superpositional(F).
 compile_this_s('match').
 compile_this_s('do').
 compile_this_s('do-all').

--- a/prolog/metta_lang/metta_compiler_lib.pl
+++ b/prolog/metta_lang/metta_compiler_lib.pl
@@ -892,6 +892,38 @@ mc('limit',N,S,R) :- integer(N),N>=0,limit(N,as_p1_exec(S,R)).
 transpiler_predicate_store(builtin, 'limit!', [2], '@doc', '@doc', [x(doeval,eager,[number]),x(doeval,lazy,[])], x(doeval,eager,[])).
 mc('limit!',N,S,R) :- integer(N),N>=0,limit(N,as_p1_exec(S,R)).
 
+% SUPERPOSITIONAL TRAIT SYSTEM
+% Define functions that implement superpositional behavior
+
+superpositional_function('superpose').
+superpositional_function('hyperpose').
+% add others too when needed
+
+% Trait checker predicate
+is_superpositional(FuncName) :-
+    superpositional_function(FuncName).
+
+% Register hyperpose with transpiler
+transpiler_predicate_store(builtin, hyperpose, [1], '@doc', '@doc', 
+                          [x(doeval,eager,[])], x(noeval,eager,[])).
+
+% Implement mc predicate for hyperpose with concurrent_maplist
+mc('hyperpose',S,R) :- 
+    is_list(S), 
+    length(S, Len),
+    (   Len >= 2,
+        \+ option_value(threading,false)
+    ->  concurrent_maplist(eval_superpositional_element, S, Results),
+        member(R, Results)
+    ;   % Fallback to regular superpose behavior
+        member(E, S), 
+        as_p1_exec(E, R)
+    ).
+
+% Helper predicate for concurrent evaluation
+eval_superpositional_element(Element, Result) :-
+    as_p1_exec(Element, Result).
+
 %%%%%%%%%%%%%%%%%%%%% superpose, collapse
 
 transpiler_predicate_store(builtin, superpose, [1], '@doc', '@doc', [x(doeval,eager,[])], x(noeval,eager,[])).

--- a/prolog/metta_lang/metta_eval.pl
+++ b/prolog/metta_lang/metta_eval.pl
@@ -331,7 +331,9 @@ allow_repeats_eval_(_):- !.
 allow_repeats_eval_(_):- option_value(no_repeats,false),!.
 allow_repeats_eval_(X):- \+ is_list(X),!,fail.
 allow_repeats_eval_([F|_]):- atom(F),allow_repeats_eval_f(F).
-allow_repeats_eval_f('superpose').
+allow_repeats_eval_([F|_]):- 
+    atom(F), 
+    (is_superpositional(F) ; allow_repeats_eval_f(F)).
 allow_repeats_eval_f('collapse').
 
 as_prolog_x(_,Self,X,XX):- quietly(as_prolog(0,Self,X,XX)), !.
@@ -2220,7 +2222,6 @@ eval_10(Eq,RetType,Depth,Self,['collapse',List],RetVal):- is_list(List),
 eval_10(Eq,RetType,Depth,Self,['collapse',List],Res):-!,
  findall_eval(Eq,RetType,Depth,Self,List,Res).
 
-
 eval_10(Eq,RetType,Depth,Self,['superpose',List],Res):- !,
        member(E,List),
        eval_ret(Eq,RetType,Depth,Self,E,Res).
@@ -2247,11 +2248,13 @@ get_sa_p1(P3,E,Cmpd,SA):-  compound(Cmpd), get_sa_p2(P3,E,Cmpd,SA).
 get_sa_p2(P3,E,Cmpd,call(P3,N1,Cmpd)):- arg(N1,Cmpd,E),nocut.
 get_sa_p2(P3,E,Cmpd,SA):- arg(_,Cmpd,Arg),get_sa_p1(P3,E,Arg,SA).
 
+% Replace hardcoded superpose check with trait check
 eval20_failed(Eq,RetType,Depth,Self, Term, Res):-
-  notrace(( get_sa_p1(setarg,ST,Term,P1), % ST\==Term,
-   compound(ST), ST = [F,List],F=='superpose',nonvar(List), %maplist(atomic,List),
+  notrace(( get_sa_p1(setarg,ST,Term,P1),
+   compound(ST), ST = [F,List],
+   is_superpositional(F),  % CHANGED: was F=='superpose'
+   nonvar(List),
    call(P1,Var))), !,
-   %max_counting(F,20),
    member(Var,List),
    eval_args(Eq,RetType,Depth,Self, Term, Res).
 
@@ -3171,7 +3174,7 @@ eval_20(Eq,RetType,Depth,Self,['concurrent-forall!',Gen,Test|Options],NoResult):
 eval_20(Eq,RetType,Depth,Self,['hyperpose',ArgL],Res):- !,
    metta_hyperpose(Eq,RetType,Depth,Self,ArgL,Res).
 
-         %eval_args(Eq,RetType,Depth,Self,['superpose',ArgL],Res)).
+         %eval_args(Eq,RetType,Depth,Self,['superpose',ArgL],Res).
 
 
 

--- a/prolog/metta_lang/metta_threads.pl
+++ b/prolog/metta_lang/metta_threads.pl
@@ -676,30 +676,26 @@ maplist_([X1|Xs1], [X2|Xs2], [X3|Xs3], [X4|Xs4], [X5|Xs5], [X6|Xs6], [X7|Xs7], G
 %   @arg InList The input list.
 %   @arg Res The result.
 %
+%  hyperpose that uses existing concurrent maplist implementation
 metta_hyperpose(Eq, RetType, Depth, MSpace, InList, Res) :-
- \+ option_value(threading,false),!,
- %with_metta_ctx(Eq, RetType, Depth, MSpace, ['hyperpose'|InList], metta_hyperpose_v0(eval, InList, Res)).
-  with_metta_ctx(Eq, RetType, Depth, MSpace, ['hyperpose'|InList], metta_hyperpose_v0(eval_args(Eq, RetType, Depth, MSpace), InList, Res)).
-
-metta_hyperpose(Eq, RetType, Depth, MSpace, InList, Res) :-
-    % This part of the code is currently skipped with fail.
-    % fail,
     \+ option_value(threading,false),
-    % Check if InList has two or more elements.
-    InList = [_,_|_],!,
-    !,  % Cut to ensure threading is used.
-    % Setup concurrent processing with cleanup.
-    setup_call_cleanup(
-             % Assert results after concurrent computation.
-             concurrent_assert_result(eval_args(Eq, RetType, Depth, MSpace), InList, Tag),
-             % Gather each result in order.
-             each_result_in_order(Tag, InList, Res),
-             % Cleanup the results after processing.
-             cleanup_results(Tag)).
+    InList = [_,_|_],  % At least 2 elements
+    !,
+    % Use existing metta_concurrent_maplist
+    metta_concurrent_maplist(
+        eval_hyperpose_element(Eq,RetType,Depth,MSpace), 
+        InList, 
+        Results
+    ),
+    member(Res, Results).
 
-metta_hyperpose(Eq, RetType, Depth, MSpace, ArgL, Res) :-
-    % Evaluate the equation using single-threaded approach.
-    eval_args(Eq, RetType, Depth, MSpace, ['superpose', ArgL], Res).
+% Fallback to superpose behavior
+metta_hyperpose(Eq, RetType, Depth, MSpace, InList, Res) :-
+    eval_args(Eq, RetType, Depth, MSpace, ['superpose', InList], Res).
+
+% Helper for concurrent evaluation
+eval_hyperpose_element(Eq,RetType,Depth,MSpace, Element, Result) :-
+    eval_args(Eq, RetType, Depth, MSpace, Element, Result).
 
 %!  concurrent_assert_result(:P2, +InList, -Tag) is det.
 %


### PR DESCRIPTION
## Summary

This PR introduces a **trait-based system for superpositional(non-deterministic) functions** in the MeTTa compiler and evaluator. Instead of hardcoding checks for `superpose`, a generic `is_superpositional/1` predicate is used, making the system extensible for future operators (currently for `hyperpose`).

For implementing `hyperpose` the prolog `concurrent_maplist` is being used that evaluates all elements in parallel, then lets you choose from the results nondeterministically.
Description for it: https://www.swi-prolog.org/pldoc/doc_for?object=concurrent_maplist/2
